### PR TITLE
Add -P --prefix option

### DIFF
--- a/gcg/entrypoint.py
+++ b/gcg/entrypoint.py
@@ -144,7 +144,7 @@ def parse_args(argv):
         action="count", default=0
     )
     parser.add_argument(
-        '-P', '--prefix',
+        '-P', '--tag-prefix',
         help="""Prefix to be stripped off tags before processing.
         eg.: specifying v recognizes tags like v1.0.0 v1.0.1 and
         processes them as if the were 1.0.0 1.0.1""",
@@ -197,8 +197,8 @@ def collate_entry_header_data(repo, entries, options):
             logging.info("Retrieving details of tag '%s'", version)
             hdr = log_entry_header_from_tag(repo.tags[version].tag)
         stripped = version
-        if options.prefix and stripped.startswith(options.prefix):
-            stripped = stripped[len(options.prefix):]
+        if options.tag_prefix and stripped.startswith(options.tag_prefix):
+            stripped = stripped[len(options.tag_prefix):]
         hdr['version'] = stripped or options.current_version
         hdr['deb_urgency'] = options.deb_urgency
         hdr['deb_distro'] = options.deb_distribution
@@ -412,7 +412,7 @@ def traverse_version_tree(client, repo, options, upper_limit, lower_limit):
     curr_entry = list()
     curr_tag = ''
     bugtracking_regexp = re.compile(options.bug_tracking_pattern, re.MULTILINE)
-    tag_filter = TagFilter(None, options.prefix)
+    tag_filter = TagFilter(None, options.tag_prefix)
 
     for commit in repo_iterate(repo, upper_limit, lower_limit):
         logging.debug("Processing commit %s (%s)", commit.hexsha,

--- a/gcg/entrypoint.py
+++ b/gcg/entrypoint.py
@@ -197,7 +197,7 @@ def collate_entry_header_data(repo, entries, options):
             logging.info("Retrieving details of tag '%s'", version)
             hdr = log_entry_header_from_tag(repo.tags[version].tag)
         stripped = version
-        if stripped and stripped.startswith(options.prefix):
+        if options.prefix and stripped.startswith(options.prefix):
             stripped = stripped[len(options.prefix):]
         hdr['version'] = stripped or options.current_version
         hdr['deb_urgency'] = options.deb_urgency

--- a/tests/helpers/gitrepo.py
+++ b/tests/helpers/gitrepo.py
@@ -12,18 +12,22 @@ import git
 AUTHOR = git.Actor("Pytest Forever", "author@example.com")
 
 
-def prepare_git_repo(root, dirname='testrepo', messages=None):
+def prepare_git_repo(root, dirname='testrepo', messages=None,
+                     messages_and_tags=None):
     """Create a Git repository at a given path
     and optionally pre-populate it with commits
 
     :param root: root directory
     :param dirname: repository directory (within root). This directory
                     will be automatically created.
-    :param messages: a list of strings which will be used for commit messages
-
+    :param messages: a list of strings which will be used for commit messages.
+    :param messages_and_tag: a list of tuples which will be used for commit
+                             messages and corresponding tags.
     """
     if messages is None:
         messages = []
+    if messages_and_tags is None:
+        messages_and_tags = []
     # This is so that CI environment doesn't override it
     os.environ['GIT_AUTHOR_NAME'] = AUTHOR.name
     os.environ['GIT_AUTHOR_EMAIL'] = AUTHOR.email
@@ -40,5 +44,9 @@ def prepare_git_repo(root, dirname='testrepo', messages=None):
     # commit by commit message and author and committer
     for msg in messages:
         index.commit(msg)
+    for msg_with_tag in messages_and_tags:
+        commit = index.commit(msg_with_tag[0])
+        if msg_with_tag[1] is not None:
+            repo.create_tag(msg_with_tag[1], commit)
 
     return (path, repo, client)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -231,3 +231,48 @@ class TestMain(object):
         count = len(lines)
         for i in range(1, count):
             assert lines[count-i].startswith('- {}'.format(i))
+
+    def test_without_prefix(self):
+        input_data = [
+            ("1st", None),
+            ("2nd", None),
+            ("3rd", "v1.0.0"),
+            ("4th", None),
+            ("5th", "v1.0.1"),
+            ("6th", None)
+        ]
+        # pylint: disable=unused-variable
+        (path, repo, client) = prepare_git_repo(
+            self.tmp_dir, messages_and_tags=input_data)
+        out_file = os.path.join(self.tmp_dir, 'outfilexx')
+        assert err.SUCCESS == gcg.entrypoint.main([
+            'xyz', '-p', path, '-O', 'rpm', '-o', out_file])
+        assert os.path.exists(out_file)
+        lines = [line.rstrip('\n') for line in open(out_file)]
+        count = len(lines) - 1
+        assert count == 7
+        assert lines[0].endswith('> - current')
+        for i in range(1, count):
+            assert lines[count-i].startswith('- {}'.format(i))
+
+    def test_with_prefix(self):
+        input_data = [
+            ("1st", None),
+            ("2nd", None),
+            ("3rd", "v1.0.0"),
+            ("4th", None),
+            ("5th", "v1.0.1"),
+            ("6th", None)
+        ]
+        # pylint: disable=unused-variable
+        (path, repo, client) = prepare_git_repo(
+            self.tmp_dir, messages_and_tags=input_data)
+        out_file = os.path.join(self.tmp_dir, 'outfilexx')
+        assert err.SUCCESS == gcg.entrypoint.main([
+            'xyz', '-p', path, '-O', 'rpm', '-o', out_file, '-P', 'v'])
+        assert os.path.exists(out_file)
+        lines = [line.rstrip('\n') for line in open(out_file)]
+        assert len(lines) == 12
+        assert lines[0].endswith('> - current')
+        assert lines[3].endswith('> - 1.0.1')
+        assert lines[7].endswith('> - 1.0.0')


### PR DESCRIPTION
While figuring out why my custom tag pattern did not work, I stumbled over
the prefix parameter of the TagFilter class. This turned out to be the ideal
functionality to be use with [this](https://github.com/felfert/catlock) repository where the tags start with 'v'.

This PR adds a new option -P --prefix for specifying a prefix.
The next PR will fix the actual bug where the custom pattern is not used when
creating TagFilter object.