### PR TITLE
Fix custom tag pattern

### DIFF
--- a/gcg/entrypoint.py
+++ b/gcg/entrypoint.py
@@ -402,7 +402,7 @@ def traverse_version_tree(client, repo, options, upper_limit, lower_limit):
     curr_entry = list()
     curr_tag = ''
     bugtracking_regexp = re.compile(options.bug_tracking_pattern, re.MULTILINE)
-    tag_filter = TagFilter(None)
+    tag_filter = TagFilter(options.custom_tag_pattern)
 
     for commit in repo_iterate(repo, upper_limit, lower_limit):
         logging.debug("Processing commit %s (%s)", commit.hexsha,


### PR DESCRIPTION
This PR fixes the custom-tag-pattern option which is not used when
creating the TagFilter object.

Note:
Since this PR and the previous one are both against your current master,
this PR will fail to merge after #34 is merged, but since *this* PR is only a
one-liner that should be trivial.