### PR TITLE
Eliminate double empty line in deb template

### DIFF
--- a/gcg/templates/deb
+++ b/gcg/templates/deb
@@ -2,7 +2,6 @@
 
 {%   for c in entries[e] %}  * {{ c.message.split('\n', 1)[0].strip() }} (rev.{{ c.hexsha[0:8] }})
 {%   endfor %}
-
  -- {{ headers[e]['author'] }} <{{ headers[e]['email'] }}>  {{ headers[e]['date_deb'] }}
 
 {% endfor %}


### PR DESCRIPTION
As discussed earlier, this PR reduces the double empty line in the debian template to one.