### PR TITLE
Support python3

### DIFF
--- a/gcg/entrypoint.py
+++ b/gcg/entrypoint.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 
 """
 gcg stands for Git Changelog Generator

--- a/gcg/errors.py
+++ b/gcg/errors.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 
 """
 Definition of exit codes for the main()

--- a/gcg/jinja_filters.py
+++ b/gcg/jinja_filters.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 
 """
 Collection of filter functions which can be used in Jinja2 templates

--- a/gcg/tag_filter.py
+++ b/gcg/tag_filter.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 """
 All functionality related to filtering out Git tags against
 Semantic Versioning or custum rules

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 
 """
 Setuptools configuration for GCG project

--- a/tests/helpers/gitrepo.py
+++ b/tests/helpers/gitrepo.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python
 # encoding: utf-8
 
 '''

--- a/tests/test_input.py
+++ b/tests/test_input.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 
 """Unit tests for various combinations of main() parameters"""
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 
 """
 Unit and component tests for the main module
@@ -126,7 +126,7 @@ class TestMain(object):
         assert os.path.exists(out_file)
 
         lines = [line.rstrip('\n') for line in open(out_file)]
-        lines = filter(len, lines)
+        lines = list(filter(len, lines))
         assert lines[0] == 'foopkg (current) xenial; urgency=low'
         assert lines[1].startswith('  * Second')
         assert lines[2].startswith('  * First')
@@ -151,7 +151,7 @@ class TestMain(object):
         assert os.path.exists(out_file)
 
         lines = [line.rstrip('\n') for line in open(out_file)]
-        lines = filter(len, lines)
+        lines = list(filter(len, lines))
         assert lines[0] == 'package (current) xenial; urgency=high'
         assert lines[1].startswith('  * First')
 
@@ -225,7 +225,7 @@ class TestMain(object):
         assert os.path.exists(out_file)
 
         lines = [line.rstrip('\n') for line in open(out_file)]
-        lines = filter(len, lines)
+        lines = list(filter(len, lines))
         print(lines)
 
         count = len(lines)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -126,7 +126,7 @@ class TestMain(object):
         assert os.path.exists(out_file)
 
         lines = [line.rstrip('\n') for line in open(out_file)]
-        lines = filter(len, lines)
+        lines = list(filter(len, lines))
         assert lines[0] == 'foopkg (current) xenial; urgency=low'
         assert lines[1].startswith('  * Second')
         assert lines[2].startswith('  * First')
@@ -151,7 +151,7 @@ class TestMain(object):
         assert os.path.exists(out_file)
 
         lines = [line.rstrip('\n') for line in open(out_file)]
-        lines = filter(len, lines)
+        lines = list(filter(len, lines))
         assert lines[0] == 'package (current) xenial; urgency=high'
         assert lines[1].startswith('  * First')
 
@@ -225,7 +225,7 @@ class TestMain(object):
         assert os.path.exists(out_file)
 
         lines = [line.rstrip('\n') for line in open(out_file)]
-        lines = filter(len, lines)
+        lines = list(filter(len, lines))
         print(lines)
 
         count = len(lines)

--- a/tests/test_output_templates.py
+++ b/tests/test_output_templates.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 
 """Unit test suite for functions related to version handling"""
 

--- a/tests/test_standalone_functions.py
+++ b/tests/test_standalone_functions.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python
 # encoding: utf-8
 
 '''

--- a/tests/test_tag_filter.py
+++ b/tests/test_tag_filter.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 """
 Unit tests for version validation and matching
 """


### PR DESCRIPTION
While developing a test for the custom filter parameterization I got some very strange errors in pylint.
I'm using Fedora29 which has mostly moved to python3 so I suspect this to be a bug in the distro.
So I tried gcg with python3 and after making some minor changes the tests work nicely here.
I also changed the .travis.yml in order to set a matrix job. See [my travis build logs](https://travis-ci.org/felfert/git-changelog-generator/builds/556755090). (This would be just another PR). Of course, I can't test deployment there.
