### PR TITLE
Show local timezone in debian changelog and use local timezone for adjusting time/date

### DIFF
--- a/requirements_install.txt
+++ b/requirements_install.txt
@@ -1,3 +1,4 @@
 jinja2>=2.10
 semver>=2.0.1
 GitPython>=1.0.1
+tzlocal>=1.5.1

--- a/requirements_setup.txt
+++ b/requirements_setup.txt
@@ -2,5 +2,6 @@ pip>=9.0.1
 jinja2>=2.10
 semver>=2.0.1
 GitPython>=1.0.1
+tzlocal>=1.5.1
 stdeb==0.8.5
 pytest-runner==4.0


### PR DESCRIPTION
Fixes #4
Using tzlocal, because dateutil.tzlocal is broken.

### Notes:
* No test with this one, because that would be fooling yourself (everything would need to be mocked anyway because the time zone of the test system is not predictable). We simply have to trust tzlocal doing it right.
* No cmdline option either, since the proper way to set the time zone of a local process would be setting the TZ environment variable