### PR TITLE
Timezone followup

### DIFF
--- a/gcg/entrypoint.py
+++ b/gcg/entrypoint.py
@@ -217,7 +217,7 @@ def log_entry_header_from_commit(the_commit, localtz):
     hdr = dict()
     hdr['date'] = datetime.fromtimestamp(the_commit.authored_date, localtz)
     hdr['date_rpm'] = hdr['date'].strftime('%a %b %d %Y')
-    hdr['date_deb'] = hdr['date'].strftime('%a, %d %b %Y %H:%M:S %z')
+    hdr['date_deb'] = hdr['date'].strftime('%a, %d %b %Y %H:%M:%S %z')
     hdr['author'] = str(the_commit.author.name)
     hdr['email'] = str(the_commit.author.email)
     return hdr


### PR DESCRIPTION
This PR fixes the typo and adds 2 tests for validating the formatting of the timestamps in rpm and deb changelogs.