### PR TITLE
Fix #41

### DIFF
--- a/gcg/entrypoint.py
+++ b/gcg/entrypoint.py
@@ -191,7 +191,9 @@ def collate_entry_header_data(repo, entries, options):
     """
     retval = {}
     for version in entries:
-        if not version or (entries[version] and not options.prefer_tags):
+        if not version or (entries[version]
+                           and (repo.tags[version].tag is None
+                                or (not options.prefer_tags))):
             hdr = log_entry_header_from_commit(entries[version][0])
         else:
             logging.info("Retrieving details of tag '%s'", version)

--- a/tests/helpers/gitrepo.py
+++ b/tests/helpers/gitrepo.py
@@ -12,6 +12,17 @@ import git
 AUTHOR = git.Actor("Pytest Forever", "author@example.com")
 
 
+def change_author_email(repo, email):
+    """Change author email. The git config must already be initialized.
+    :param repo: The repository to use.
+    :param email: The new email address.
+    """
+    if email is not None:
+        writer = repo.config_writer(config_level='repository')
+        writer.set('user', 'email', email)
+        writer.release()
+
+
 def prepare_git_repo(root, dirname='testrepo', messages=None,
                      messages_and_tags=None):
     """Create a Git repository at a given path
@@ -23,6 +34,11 @@ def prepare_git_repo(root, dirname='testrepo', messages=None,
     :param messages: a list of strings which will be used for commit messages.
     :param messages_and_tag: a list of tuples which will be used for commit
                              messages and corresponding tags.
+                             If the tuple has 2 elements, then a lightweight
+                             tag is created. If the tuple has 3 elements,
+                             then an annotated tag is created. If the tuple
+                             has 4 elements, the fourth element is used as
+                             mail-address of the tag-committer.
     """
     if messages is None:
         messages = []
@@ -47,6 +63,13 @@ def prepare_git_repo(root, dirname='testrepo', messages=None,
     for msg_with_tag in messages_and_tags:
         commit = index.commit(msg_with_tag[0])
         if msg_with_tag[1] is not None:
-            repo.create_tag(msg_with_tag[1], commit)
+            if len(msg_with_tag) > 3:
+                change_author_email(repo, msg_with_tag[3])
+                repo.create_tag(msg_with_tag[1], commit, msg_with_tag[2])
+                change_author_email(repo, AUTHOR.email)
+            elif len(msg_with_tag) > 2:
+                repo.create_tag(msg_with_tag[1], commit, msg_with_tag[2])
+            else:
+                repo.create_tag(msg_with_tag[1], commit)
 
     return (path, repo, client)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -276,3 +276,30 @@ class TestMain(object):
         assert lines[0].endswith('> - current')
         assert lines[3].endswith('> - 1.0.1')
         assert lines[7].endswith('> - 1.0.0')
+
+    def test_prefer_tags(self):
+        input_data = [
+            ("1st", None),
+            ("2rd", "1.0.0"),
+            ("3rd", None),
+            ("4th", "1.0.1", "tagmsg1"),
+            ("5th", None),
+            ("6th", "1.0.2", "tagmsg2", "me@nowhere.org"),
+            ("7th", None)
+        ]
+        # pylint: disable=unused-variable
+        (path, repo, client) = prepare_git_repo(
+            self.tmp_dir, messages_and_tags=input_data)
+        out_file = os.path.join(self.tmp_dir, 'outfile')
+        assert err.SUCCESS == gcg.entrypoint.main([
+            'xyz', '-p', path, '-O', 'rpm', '-o', out_file, '-t'])
+        assert os.path.exists(out_file)
+        lines = [line.rstrip('\n') for line in open(out_file)]
+        assert len(lines) == 15
+        assert lines[0].endswith('> - current')
+        assert lines[3].endswith('> - 1.0.2')
+        assert lines[3].find('me@nowhere.org') > 0
+        assert lines[7].endswith('> - 1.0.1')
+        assert lines[7].find('author@example.com') > 0
+        assert lines[11].endswith('> - 1.0.0')
+        assert lines[11].find('author@example.com') > 0


### PR DESCRIPTION
This one supersedes PR #42 (rebased to resolve conflicts after timezone-stuff was merged)

The reason for Issue #41 is, that it assumes all tags have a date and author. However this assumption is false. Normally tags are "lightweight" which means they are only a reference to some commit. Only when using -a (annotate) during creation, tags become "heavy" which means that they have a commit message and author and a date (just like normal commits).

