### PR TITLE
Add license reference to README.rst

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,0 @@
-
-
-## License
-
-This project is licensed under the BSD-3-Clause license - see the [LICENSE](https://github.com/nokia/git-changelog-generator/blob/master/LICENSE).

--- a/README.md
+++ b/README.md
@@ -1,0 +1,5 @@
+
+
+## License
+
+This project is licensed under the BSD-3-Clause license - see the [LICENSE](https://github.com/nokia/git-changelog-generator/blob/master/LICENSE).

--- a/README.rst
+++ b/README.rst
@@ -159,3 +159,9 @@ RPM template
 
 Based on one of allowed formats listed at
 https://fedoraproject.org/wiki/Packaging:Guidelines?rd=Packaging/Guidelines#Changelogs
+
+
+License
+-------
+
+This project is licensed under the BSD-3-Clause license - see the `LICENSE <https://github.com/nokia/git-changelog-generator/blob/master/LICENSE>`_.


### PR DESCRIPTION
Adds a refrence to the project license to README.md. This is considered a best-practice.